### PR TITLE
picard log used pairs;but ataqc use total reads (*2 for each pair)

### DIFF
--- a/run_ataqc.py
+++ b/run_ataqc.py
@@ -510,7 +510,7 @@ def get_picard_dup_stats(picard_dup_file, paired_status):
                 dup_stats['READ_PAIR_DUPLICATES'] = line_elems[5]
                 dup_stats['READ_PAIRS_EXAMINED'] = line_elems[2]
                 if paired_status == 'Paired-ended':
-                    return int(2*line_elems[5]), float(line_elems[7])
+                    return 2*int(line_elems[5]), float(line_elems[7])
                 else:
                     return int(line_elems[4]), float(line_elems[7])
 

--- a/run_ataqc.py
+++ b/run_ataqc.py
@@ -510,9 +510,9 @@ def get_picard_dup_stats(picard_dup_file, paired_status):
                 dup_stats['READ_PAIR_DUPLICATES'] = line_elems[5]
                 dup_stats['READ_PAIRS_EXAMINED'] = line_elems[2]
                 if paired_status == 'Paired-ended':
-                    return float(line_elems[5]), float(line_elems[7])
+                    return int(2*line_elems[5]), float(line_elems[7])
                 else:
-                    return float(line_elems[4]), float(line_elems[7])
+                    return int(line_elems[4]), float(line_elems[7])
 
             if mark > 0:
                 mark += 1


### PR DESCRIPTION
see title